### PR TITLE
feat : EKS - 노드그룹에 제한적 admin 권한부여 certmanager 설치용

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,6 +72,9 @@ module "eks" {
   # SSM Access
   enable_ssm_access = var.enable_ssm_access
 
+  # Node Group Limited Admin Access (for cert-manager installation)
+  enable_node_group_limited_admin = var.enable_node_group_limited_admin
+
   # Tags
   common_tags = var.common_tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -73,6 +73,12 @@ variable "enable_ssm_access" {
   default     = true
 }
 
+variable "enable_node_group_limited_admin" {
+  description = "Enable limited admin access for EKS node group (for cert-manager installation)"
+  type        = bool
+  default     = false
+}
+
 # EKS Configuration (Production Scale)
 variable "eks_cluster_version" {
   description = "EKS cluster version"


### PR DESCRIPTION
## ✨ 변경 내용
feat : EKS - 노드그룹에 제한적 admin 권한부여 certmanager 설치용
테라폼 클라우드에서 변수처리해서 
true 로 하면 노드그룹에 관리용으로 eks admin 권한이 부여되어 certmanager 설치할 수 있게 수정했습니다. 

---

## 📌 관련 이슈
- resolved: #이슈번호

---

## ✅ 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---

## 💬 기타 사항
-
