### PR TITLE
feat : EKS - 노드그룹에 제한적 admin 권한부여

### DIFF
--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -144,6 +144,31 @@ resource "aws_iam_role_policy" "node_group_ssm_custom" {
   })
 }
 
+# EKS Node Group Management Policy (cert-manager + ArgoCD 배포용)
+resource "aws_iam_role_policy" "node_group_management" {
+  count = var.enable_node_group_limited_admin ? 1 : 0
+  
+  name = "${var.project_name}-${var.environment}-eks-node-management"
+  role = aws_iam_role.node_group.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "eks:UpdateNodegroupConfig",
+          "eks:UpdateNodegroupVersion",
+          "ec2:RebootInstances",
+          "ec2:DescribeInstances",
+          "ec2:DescribeInstanceStatus"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
 # EBS CSI Driver IAM Policy
 resource "aws_iam_policy" "ebs_csi_driver" {
   name        = "${var.project_name}-${var.environment}-ebs-csi-driver-policy"


### PR DESCRIPTION
## ✨ 변경 내용
-EKS - 노드그룹에 제한적 admin 권한부여
node_group IAM Role에 연결된 정책들:
기본 EKS 정책들 (필수):
AmazonEKSWorkerNodePolicy - EKS 워커 노드 기본 권한
AmazonEKS_CNI_Policy - CNI 네트워킹 권한
AmazonEC2ContainerRegistryReadOnly - ECR 읽기 권한
SSM 관련 정책들 (조건부):
AmazonSSMManagedInstanceCore - SSM 기본 권한
ssm_parameter_read - SSM 파라미터 읽기 권한
ssm_eks_access - EKS API 접근 권한 (기존)
node_group_ssm_custom - SSM 메시징 권한 (기존)
관리 권한들 (새로 추가, 중복 제거됨):
node_group_management - 노드 그룹 관리 + EC2 재시작 권한
EKS Access Entry (Kubernetes 권한):
AmazonEKSAdminPolicy - cert-manager, ArgoCD 설치 권한

---

## 📌 관련 이슈
- resolved: #이슈번호

---

## ✅ 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---

## 💬 기타 사항
-
