### PR TITLE
feat : ALB에서 EKS NodeGroup의 ArgoCD 서버로의 8080 포트 접근 허용을 위한 보안 그룹 규칙 추가

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -549,6 +549,22 @@ module "argocd" {
   ]
 }
 
+# ALB → EKS NodeGroup SG: ArgoCD 서버 targetPort(8080) 허용
+resource "aws_security_group_rule" "allow_alb_to_nodes_argo_8080" {
+  type                     = "ingress"
+  description              = "Allow ALB to reach ArgoCD server on targetPort 8080"
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+  security_group_id        = module.eks.node_group_security_group_id
+  source_security_group_id = module.alb.alb_security_group_id
+
+  depends_on = [
+    module.alb,
+    module.eks
+  ]
+}
+
 # EKS 클러스터와 Helm 차트는 Terraform으로 자동 배포됩니다
 # GitOps 설정만 수동으로 진행하면 됩니다
 


### PR DESCRIPTION
## ✨ 변경 내용
- ALB에서 EKS NodeGroup의 ArgoCD 서버로의 8080 포트 접근 허용을 위한 보안 그룹 규칙 추가

---

## 📌 관련 이슈
- resolved: #이슈번호

---

## ✅ 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---

## 💬 기타 사항
-
