### PR TITLE
[Feature] Grafana 대시보드 부트스트랩 및 Ingress/SG/데이터소스 설정 개선

### DIFF
--- a/modules/alb/outputs.tf
+++ b/modules/alb/outputs.tf
@@ -55,3 +55,8 @@ output "helm_values" {
     vpcId  = var.vpc_id
   }
 } 
+
+output "alb_sg_id" {
+  description = "ALB(Security Group) ID"
+  value       = aws_security_group.alb.id
+}

--- a/modules/monitoring/grafana/dashboards.tf
+++ b/modules/monitoring/grafana/dashboards.tf
@@ -1,0 +1,28 @@
+# 대시보드 파일 목록을 읽어서 파일마다 ConfigMap 1개씩 생성
+# 이유: ConfigMap 1개당 1MB 제한 회피를 위해 파일별로 분리
+locals {
+  dashboard_files = fileset("${path.module}/dashboards", "*.json")
+}
+
+resource "kubernetes_config_map" "grafana_dashboards" {
+  for_each = { for f in local.dashboard_files : f => f }
+
+  metadata {
+    # 파일명에서 .json 제거하고 이름에 안전한 문자만 사용
+    name      = "grafana-dashboard-${replace(regex("\\.json$", each.key), "/[^a-zA-Z0-9-]/", "-")}"
+    namespace = var.namespace
+    labels = {
+      # values.yaml의 sidecar가 읽어가는 라벨
+      grafana_dashboard = "1"
+    }
+  }
+
+  # 파일 내용을 그대로 ConfigMap에 탑재
+  data = {
+    # key는 대시보드 파일명 (그대로 유지)
+    "${each.key}" = file("${path.module}/dashboards/${each.key}")
+  }
+
+  # Grafana(Helm)가 먼저 올라온 뒤 사이드카가 읽게끔 순서 보장
+  depends_on = [helm_release.grafana]
+}

--- a/modules/monitoring/grafana/dashboards.tf
+++ b/modules/monitoring/grafana/dashboards.tf
@@ -1,28 +1,36 @@
-# 대시보드 파일 목록을 읽어서 파일마다 ConfigMap 1개씩 생성
-# 이유: ConfigMap 1개당 1MB 제한 회피를 위해 파일별로 분리
+# 대시보드 파일별로 ConfigMap 1개 생성
 locals {
   dashboard_files = fileset("${path.module}/dashboards", "*.json")
+
+  # 파일명 정규화 준비: .json 제거 → 소문자
+  dash_base = {
+    for f in local.dashboard_files :
+    f => lower(replace(f, ".json", ""))
+  }
+
+  # 허용문자(a-z0-9.-)만 남기고 양끝의 .,- 제거
+  dash_safe = {
+    for f, name in local.dash_base :
+    f => trim(join("", regexall("[a-z0-9.-]", name)), ".-")
+  }
 }
 
 resource "kubernetes_config_map" "grafana_dashboards" {
   for_each = { for f in local.dashboard_files : f => f }
 
+  # K8s 이름 63자 제한 대비: md5 해시로 유니크 보장 + 전체 substr
   metadata {
-    # 파일명에서 .json 제거하고 이름에 안전한 문자만 사용
-    name      = "grafana-dashboard-${trim(regexreplace(regexreplace(lower(regexreplace(each.key, "\\.json$", "")), "[^a-z0-9.-]", "-"), "^-+|\\.+$|[-.]+$", "-"), "-.")}"
+    name      = substr("grafana-dashboard-${substr(md5(each.key),0,6)}-${local.dash_safe[each.key]}", 0, 63)
     namespace = var.namespace
     labels = {
-      # values.yaml의 sidecar가 읽어가는 라벨
-      grafana_dashboard = "1"
+      grafana_dashboard = "1" # Grafana sidecar가 보는 라벨
     }
   }
 
-  # 파일 내용을 그대로 ConfigMap에 탑재
   data = {
-    # key는 대시보드 파일명 (그대로 유지)
+    # 키는 원래 파일명 유지 (사이드카가 내용만 읽음)
     "${each.key}" = file("${path.module}/dashboards/${each.key}")
   }
 
-  # Grafana(Helm)가 먼저 올라온 뒤 사이드카가 읽게끔 순서 보장
   depends_on = [helm_release.grafana]
 }

--- a/modules/monitoring/grafana/dashboards.tf
+++ b/modules/monitoring/grafana/dashboards.tf
@@ -9,7 +9,7 @@ resource "kubernetes_config_map" "grafana_dashboards" {
 
   metadata {
     # 파일명에서 .json 제거하고 이름에 안전한 문자만 사용
-    name      = "grafana-dashboard-${replace(regex("\\.json$", each.key), "/[^a-zA-Z0-9-]/", "-")}"
+    name      = "grafana-dashboard-${trim(regexreplace(regexreplace(lower(regexreplace(each.key, "\\.json$", "")), "[^a-z0-9.-]", "-"), "^-+|\\.+$|[-.]+$", "-"), "-.")}"
     namespace = var.namespace
     labels = {
       # values.yaml의 sidecar가 읽어가는 라벨

--- a/modules/monitoring/grafana/dashboards/jvm-service.json
+++ b/modules/monitoring/grafana/dashboards/jvm-service.json
@@ -1,0 +1,201 @@
+{
+  "title": "JVM Service Overview",
+  "schemaVersion": 38,
+  "version": 2,
+  "timezone": "browser",
+  "templating": {
+    "list": [
+      {
+        "name": "namespace",
+        "type": "query",
+        "datasource": "Prometheus",
+        "query": "label_values(kube_pod_info, namespace)",
+        "includeAll": false,
+        "multi": false
+      },
+      {
+        "name": "pod",
+        "type": "query",
+        "datasource": "Prometheus",
+        "query": "label_values(kube_pod_info{namespace=\"$namespace\"}, pod)",
+        "includeAll": false,
+        "multi": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Heap Used (MB)",
+      "gridPos": { "x": 0, "y": 0, "w": 4, "h": 4 },
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "megabytes",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "value": 500, "color": "orange" },
+              { "value": 800, "color": "red" }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "jvm_memory_used_bytes{area=\"heap\",namespace=\"$namespace\",pod=\"$pod\"} / 1024 / 1024",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "GC Time (ms/s)",
+      "gridPos": { "x": 4, "y": 0, "w": 4, "h": 4 },
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "value": 200, "color": "orange" },
+              { "value": 500, "color": "red" }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(jvm_gc_pause_seconds_sum{namespace=\"$namespace\",pod=\"$pod\"}[$__rate_interval]) * 1000",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "CPU Usage (cores)",
+      "gridPos": { "x": 8, "y": 0, "w": 4, "h": 4 },
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cores",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "value": 1, "color": "orange" },
+              { "value": 2, "color": "red" }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(process_cpu_seconds_total{namespace=\"$namespace\",pod=\"$pod\"}[$__rate_interval])",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "HTTP RPS",
+      "gridPos": { "x": 12, "y": 0, "w": 4, "h": 4 },
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "unit": "reqps" } },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{namespace=\"$namespace\",pod=\"$pod\"}[$__rate_interval]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "HTTP 5xx Rate",
+      "gridPos": { "x": 16, "y": 0, "w": 4, "h": 4 },
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "value": 0.1, "color": "orange" },
+              { "value": 1, "color": "red" }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{status=~\"5..\",namespace=\"$namespace\",pod=\"$pod\"}[$__rate_interval]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "JVM Heap Usage",
+      "gridPos": { "x": 0, "y": 4, "w": 24, "h": 7 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "jvm_memory_used_bytes{area=\"heap\",namespace=\"$namespace\",pod=\"$pod\"}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "JVM Threads (Current)",
+      "gridPos": { "x": 0, "y": 11, "w": 12, "h": 7 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "jvm_threads_current{namespace=\"$namespace\",pod=\"$pod\"}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "JVM GC Time Rate",
+      "gridPos": { "x": 12, "y": 11, "w": 12, "h": 7 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "rate(jvm_gc_pause_seconds_sum{namespace=\"$namespace\",pod=\"$pod\"}[$__rate_interval])",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP Request Duration p95",
+      "gridPos": { "x": 0, "y": 18, "w": 12, "h": 7 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{namespace=\"$namespace\",pod=\"$pod\"}[$__rate_interval])))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Process CPU Usage",
+      "gridPos": { "x": 12, "y": 18, "w": 12, "h": 7 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "rate(process_cpu_seconds_total{namespace=\"$namespace\",pod=\"$pod\"}[$__rate_interval])",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/modules/monitoring/grafana/dashboards/k8s-cluster-nodes.json
+++ b/modules/monitoring/grafana/dashboards/k8s-cluster-nodes.json
@@ -1,0 +1,255 @@
+{
+  "title": "Kubernetes - Cluster & Nodes (Ops View)",
+  "schemaVersion": 38,
+  "version": 1,
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "type": "dashboard",
+        "name": "Annotations & Alerts",
+        "hide": true
+      }
+    ]
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "type": "query",
+        "datasource": "Prometheus",
+        "refresh": 1,
+        "query": "label_values(node_uname_info, instance)",
+        "includeAll": true,
+        "multi": true
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Overview",
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "Ready Nodes",
+      "gridPos": { "x": 0, "y": 1, "w": 6, "h": 4 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum(kube_node_status_condition{condition=\"Ready\",status=\"true\"})",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "NotReady Nodes",
+      "gridPos": { "x": 6, "y": 1, "w": 6, "h": 4 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum(kube_node_status_condition{condition=\"Ready\",status=\"false\"})",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "gauge",
+      "title": "Cluster CPU Usage",
+      "gridPos": { "x": 12, "y": 1, "w": 6, "h": 4 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "100 * (1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval])))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 70 },
+              { "color": "red", "value": 90 }
+            ]
+          }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["mean"], "values": false } }
+    },
+    {
+      "type": "gauge",
+      "title": "Cluster Memory Usage",
+      "gridPos": { "x": 18, "y": 1, "w": 6, "h": 4 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "100 * (1 - sum(node_memory_MemAvailable_bytes) / sum(node_memory_MemTotal_bytes))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 75 },
+              { "color": "red", "value": 90 }
+            ]
+          }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["mean"], "values": false } }
+    },
+
+    {
+      "type": "row",
+      "title": "Nodes - Detail",
+      "gridPos": { "x": 0, "y": 5, "w": 24, "h": 1 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Node CPU (%) by instance",
+      "gridPos": { "x": 0, "y": 6, "w": 24, "h": 8 },
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "unit": "percent" } },
+      "targets": [
+        {
+          "expr": "100 * (1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\",instance=~\"$instance\"}[$__rate_interval])))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Node Memory Usage (bytes)",
+      "gridPos": { "x": 0, "y": 14, "w": 24, "h": 8 },
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "targets": [
+        {
+          "expr": "node_memory_MemTotal_bytes{instance=~\"$instance\"} - node_memory_MemAvailable_bytes{instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Disk Utilization (used bytes) per device",
+      "gridPos": { "x": 0, "y": 22, "w": 24, "h": 8 },
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "targets": [
+        {
+          "expr": "max by (instance,device) (node_filesystem_size_bytes{fstype!=\"\",mountpoint!~\"/var/lib/kubelet/pods.*\"} - node_filesystem_free_bytes{fstype!=\"\",mountpoint!~\"/var/lib/kubelet/pods.*\"})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Network RX/TX (bytes/s)",
+      "gridPos": { "x": 0, "y": 30, "w": 24, "h": 8 },
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "unit": "Bps" } },
+      "targets": [
+        {
+          "expr": "sum by (instance) (rate(node_network_receive_bytes_total{device!~\"lo\",instance=~\"$instance\"}[$__rate_interval]))",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (instance) (rate(node_network_transmit_bytes_total{device!~\"lo\",instance=~\"$instance\"}[$__rate_interval]))",
+          "refId": "B"
+        }
+      ]
+    },
+
+    {
+      "type": "row",
+      "title": "At-a-glance (Top N)",
+      "gridPos": { "x": 0, "y": 38, "w": 24, "h": 1 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "table",
+      "title": "Top 5 Nodes by CPU (%)",
+      "gridPos": { "x": 0, "y": 39, "w": 12, "h": 9 },
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "unit": "percent" } },
+      "options": { "showHeader": true },
+      "targets": [
+        {
+          "expr": "topk(5, 100 * (1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]))))",
+          "refId": "A",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        { "id": "organize", "options": { "excludeByName": { "Time": true } } }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Top 5 Nodes by Memory Used (bytes)",
+      "gridPos": { "x": 12, "y": 39, "w": 12, "h": 9 },
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "options": { "showHeader": true },
+      "targets": [
+        {
+          "expr": "topk(5, node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes)",
+          "refId": "A",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        { "id": "organize", "options": { "excludeByName": { "Time": true } } }
+      ]
+    }
+  ]
+}

--- a/modules/monitoring/grafana/dashboards/k8s-workloads-overview.json
+++ b/modules/monitoring/grafana/dashboards/k8s-workloads-overview.json
@@ -1,0 +1,138 @@
+{
+  "title": "Kubernetes - Workloads Overview",
+  "schemaVersion": 38,
+  "version": 2,
+  "timezone": "browser",
+  "templating": {
+    "list": [
+      {
+        "name": "namespace",
+        "type": "query",
+        "datasource": "Prometheus",
+        "query": "label_values(kube_pod_info, namespace)",
+        "includeAll": true,
+        "multi": true
+      },
+      {
+        "name": "pod",
+        "type": "query",
+        "datasource": "Prometheus",
+        "query": "label_values(kube_pod_info{namespace=~\"$namespace\"}, pod)",
+        "includeAll": true,
+        "multi": true
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Pods Running",
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum(kube_pod_status_phase{phase=\"Running\", namespace=~\"$namespace\"})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Pods Pending/Failed",
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum(kube_pod_status_phase{phase=~\"Pending|Failed\", namespace=~\"$namespace\"})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Container CPU cores (sum by pod)",
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{image!=\"\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Container Memory bytes (sum by pod)",
+      "gridPos": { "x": 0, "y": 12, "w": 12, "h": 8 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum by (pod) (container_memory_working_set_bytes{image!=\"\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Container Restarts (rate)",
+      "gridPos": { "x": 0, "y": 20, "w": 12, "h": 8 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum by (pod) (rate(kube_pod_container_status_restarts_total{namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Namespace Summary",
+      "gridPos": { "x": 0, "y": 28, "w": 24, "h": 1 }
+    },
+    {
+      "type": "table",
+      "title": "Namespace CPU Usage (cores)",
+      "gridPos": { "x": 0, "y": 29, "w": 8, "h": 8 },
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "unit": "cores" } },
+      "targets": [
+        {
+          "expr": "sum by (namespace) (rate(container_cpu_usage_seconds_total{image!=\"\"}[5m]))",
+          "refId": "A",
+          "instant": true,
+          "format": "table"
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Namespace Memory Usage (bytes)",
+      "gridPos": { "x": 8, "y": 29, "w": 8, "h": 8 },
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "targets": [
+        {
+          "expr": "sum by (namespace) (container_memory_working_set_bytes{image!=\"\"})",
+          "refId": "A",
+          "instant": true,
+          "format": "table"
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Namespace Pods (count)",
+      "gridPos": { "x": 16, "y": 29, "w": 8, "h": 8 },
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "unit": "none" } },
+      "targets": [
+        {
+          "expr": "count by (namespace) (kube_pod_info)",
+          "refId": "A",
+          "instant": true,
+          "format": "table"
+        }
+      ]
+    }
+  ]
+}

--- a/modules/monitoring/grafana/dashboards/postgresql-rds.json
+++ b/modules/monitoring/grafana/dashboards/postgresql-rds.json
@@ -1,0 +1,173 @@
+{
+  "title": "PostgreSQL - RDS Overview",
+  "schemaVersion": 38,
+  "version": 2,
+  "timezone": "browser",
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "type": "query",
+        "datasource": "Prometheus",
+        "query": "label_values(pg_up, instance)",
+        "includeAll": false,
+        "multi": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Instance Up",
+      "gridPos": { "x": 0, "y": 0, "w": 4, "h": 4 },
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": 0 },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        { "expr": "max(pg_up{instance=\"$instance\"})", "refId": "A" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Connections",
+      "gridPos": { "x": 4, "y": 0, "w": 4, "h": 4 },
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "value": 100, "color": "orange" },
+              { "value": 200, "color": "red" }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(pg_stat_activity_count{instance=\"$instance\"})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Cache Hit Ratio",
+      "gridPos": { "x": 8, "y": 0, "w": 4, "h": 4 },
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": 0 },
+              { "color": "orange", "value": 0.9 },
+              { "color": "green", "value": 0.98 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "avg(pg_stat_database_blks_hit{instance=\"$instance\"} / (pg_stat_database_blks_hit{instance=\"$instance\"} + pg_stat_database_blks_read{instance=\"$instance\"}))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "TPS",
+      "gridPos": { "x": 12, "y": 0, "w": 4, "h": 4 },
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "targets": [
+        {
+          "expr": "sum(rate(pg_stat_database_xact_commit{instance=\"$instance\"}[$__rate_interval]) + rate(pg_stat_database_xact_rollback{instance=\"$instance\"][$__rate_interval]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Locks",
+      "gridPos": { "x": 16, "y": 0, "w": 4, "h": 4 },
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "value": 10, "color": "orange" },
+              { "value": 50, "color": "red" }
+            ]
+          }
+        }
+      },
+      "targets": [
+        { "expr": "sum(pg_locks_count{instance=\"$instance\"})", "refId": "A" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Connections by DB",
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum by (datname) (pg_stat_activity_count{instance=\"$instance\"})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Cache Hit Ratio (Trend)",
+      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 8 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "avg by (instance) (pg_stat_database_blks_hit{instance=\"$instance\"} / (pg_stat_database_blks_hit{instance=\"$instance\"} + pg_stat_database_blks_read{instance=\"$instance\"}))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Transactions per second",
+      "gridPos": { "x": 0, "y": 12, "w": 12, "h": 8 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum by (datname) (rate(pg_stat_database_xact_commit{instance=\"$instance\"}[$__rate_interval]) + rate(pg_stat_database_xact_rollback{instance=\"$instance\"}[$__rate_interval]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Locks by Mode",
+      "gridPos": { "x": 12, "y": 12, "w": 12, "h": 8 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum by (mode) (pg_locks_count{instance=\"$instance\"})",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/modules/monitoring/grafana/data.tf
+++ b/modules/monitoring/grafana/data.tf
@@ -1,0 +1,16 @@
+# Grafana LoadBalancer 서비스 정보 조회
+data "kubernetes_ingress_v1" "grafana" {
+  metadata {
+    name      = "grafana"
+    namespace = var.namespace
+  }
+
+  depends_on = [helm_release.grafana]
+}
+
+data "kubernetes_service" "prom" {
+  metadata {
+    name      = "kube-prometheus-stack-prometheus"
+    namespace = var.namespace
+  }
+}

--- a/modules/monitoring/grafana/main.tf
+++ b/modules/monitoring/grafana/main.tf
@@ -17,6 +17,18 @@ resource "helm_release" "grafana" {
     value = var.grafana_admin_password
   }
 
+  # Ingress annotation에 SG 동적 세팅
+  set {
+    # 점(.)은 키 경로 구분자라서 escape 필요
+    name  = "ingress.annotations.alb\\.ingress\\.kubernetes\\.io/security-groups"
+    value = var.alb_sg_id
+  }
+  # Prometheus ClusterIP 동적 세팅
+  set {
+    name  = "datasources.datasources\\.yaml.datasources[0].url"
+    value = "http://${data.kubernetes_service.prom.spec[0].cluster_ip}:9090"
+  }
+
   depends_on = [var.depends_on_module]
 }
 

--- a/modules/monitoring/grafana/main.tf
+++ b/modules/monitoring/grafana/main.tf
@@ -26,7 +26,7 @@ resource "helm_release" "grafana" {
   # Prometheus ClusterIP 동적 세팅
   set {
     name  = "datasources.datasources\\.yaml.datasources[0].url"
-    value = "http://${data.kubernetes_service.prom.spec[0].cluster_ip}:9090"
+    value = format("http://%s:9090", data.kubernetes_service.prom.spec[0].cluster_ip)
   }
 
   depends_on = [var.depends_on_module]
@@ -47,14 +47,4 @@ resource "aws_security_group_rule" "alb_to_nodes_grafana" {
 resource "time_sleep" "wait_for_alb" {
   depends_on       = [helm_release.grafana]
   create_duration  = "60s"
-}
-
-# Grafana LoadBalancer 서비스 정보 조회
-data "kubernetes_ingress_v1" "grafana" {
-  metadata {
-    name      = "grafana"
-    namespace = var.namespace
-  }
-
-  depends_on = [helm_release.grafana]
 }

--- a/modules/monitoring/grafana/main.tf
+++ b/modules/monitoring/grafana/main.tf
@@ -20,6 +20,17 @@ resource "helm_release" "grafana" {
   depends_on = [var.depends_on_module]
 }
 
+# ALB -> NodeSG 3000/TCP 허용 (IP 타깃 타입일 때 실제 트래픽은 노드 ENI를 지나감)
+resource "aws_security_group_rule" "alb_to_nodes_grafana" {
+  type                     = "ingress"
+  from_port                = var.grafana_target_port
+  to_port                  = var.grafana_target_port
+  protocol                 = "tcp"
+  source_security_group_id = var.alb_sg_id
+  security_group_id        = var.node_sg_id
+  description              = "Allow ALB to reach Grafana"
+}
+
 # 1) 잠깐 대기해서 ALB 붙을 시간 주기 (60초는 예시)
 resource "time_sleep" "wait_for_alb" {
   depends_on       = [helm_release.grafana]

--- a/modules/monitoring/grafana/values.yaml
+++ b/modules/monitoring/grafana/values.yaml
@@ -9,9 +9,8 @@ ingress:
     alb.ingress.kubernetes.io/target-type: "ip"
     alb.ingress.kubernetes.io/backend-protocol: "HTTP"
     alb.ingress.kubernetes.io/group.name: "monitoring"
-
-    alb.ingress.kubernetes.io/healthcheck-path: "/api/health"
-    alb.ingress.kubernetes.io/success-codes: "200"
+    alb.ingress.kubernetes.io/healthcheck-path: "/login"
+    alb.ingress.kubernetes.io/success-codes: "200-399"
     alb.ingress.kubernetes.io/healthcheck-port: "traffic-port"
   hosts:
     - grafana.goteego.store # ← 문자열 리스트!
@@ -19,13 +18,19 @@ ingress:
   pathType: Prefix
   tls: [] # 추후 HTTPS 시 ACM 연결
 
+podDnsPolicy: ClusterFirst
+podDnsConfig:
+  options:
+    - name: ndots
+      value: "1"
+
 datasources:
   datasources.yaml:
     apiVersion: 1
     datasources:
       - name: Prometheus
         type: prometheus
-        url: http://kube-prometheus-stack-prometheus:9090
+        url: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
         access: proxy
         isDefault: true
 

--- a/modules/monitoring/grafana/values.yaml
+++ b/modules/monitoring/grafana/values.yaml
@@ -9,6 +9,10 @@ ingress:
     alb.ingress.kubernetes.io/target-type: "ip"
     alb.ingress.kubernetes.io/backend-protocol: "HTTP"
     alb.ingress.kubernetes.io/group.name: "monitoring"
+
+    alb.ingress.kubernetes.io/healthcheck-path: "/login"
+    alb.ingress.kubernetes.io/success-codes: "200-399"
+    alb.ingress.kubernetes.io/healthcheck-port: "traffic-port"
   hosts:
     - grafana.goteego.store # ← 문자열 리스트!
   path: /

--- a/modules/monitoring/grafana/values.yaml
+++ b/modules/monitoring/grafana/values.yaml
@@ -10,8 +10,8 @@ ingress:
     alb.ingress.kubernetes.io/backend-protocol: "HTTP"
     alb.ingress.kubernetes.io/group.name: "monitoring"
 
-    alb.ingress.kubernetes.io/healthcheck-path: "/login"
-    alb.ingress.kubernetes.io/success-codes: "200-399"
+    alb.ingress.kubernetes.io/healthcheck-path: "/api/health"
+    alb.ingress.kubernetes.io/success-codes: "200"
     alb.ingress.kubernetes.io/healthcheck-port: "traffic-port"
   hosts:
     - grafana.goteego.store # ← 문자열 리스트!

--- a/modules/monitoring/grafana/variables.tf
+++ b/modules/monitoring/grafana/variables.tf
@@ -20,3 +20,16 @@ variable "grafana_admin_password" {
   type        = string
   sensitive   = true
 }
+
+variable "alb_sg_id" {
+  description = "ALB SG ID"
+}
+
+variable "node_sg_id" {
+  description = "EKS NodeGroup SG ID"
+}
+
+variable "grafana_target_port" {
+  description = "Grafana 서비스 포트"
+  default     = 3000
+}

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -32,6 +32,8 @@ module "grafana" {
   source                 = "./modules/monitoring/grafana"
   namespace              = "monitoring"
   chart_version          = "7.3.9"
+  alb_sg_id    = module.alb.alb_sg_id
+  node_sg_id   = module.eks.node_group_security_group_id
   depends_on_module      = module.prometheus
   grafana_admin_password = var.grafana_admin_password
 }


### PR DESCRIPTION
## ✨ 변경 내용
- Grafana Ingress 헬스체크 설정 추가 및 200 반환 경로로 수정
- Grafana Ingress에 Security Group 설정 추가
- Prometheus ClusterIP를 Grafana 데이터소스에 동적으로 세팅하도록 수정
- Grafana 기본 대시보드 여러 개 추가 (K8s, JVM, PostgreSQL 등)
- 대시보드 ConfigMap 생성 로직 개선 (파일명 충돌 회피 및 안전한 네이밍 적용)

---

## 📌 관련 이슈
- resolved: #15

---

## ✅ 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---

## 💬 기타 사항
- ConfigMap 이름 생성 시 파일명에 따라 K8s 네이밍 규칙 위반이 발생할 수 있어, 안전 문자 필터링 및 해시 프리픽스 추가
- Helm release 이후 Grafana 사이드카가 대시보드를 정상적으로 읽도록 `depends_on` 보장