### PR TITLE
feat: EKS 1.33 업그레이드로 인한 호환성점검

### DIFF
--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -505,12 +505,8 @@ resource "aws_launch_template" "node_group" {
   vpc_security_group_ids = [aws_security_group.node_group.id]
 
   # User data to ensure SSM agent is running
-  user_data = base64encode(templatefile("${path.module}/templates/user-data.sh.tpl", {
-    cluster_name      = aws_eks_cluster.main.name
-    cluster_endpoint  = aws_eks_cluster.main.endpoint
-    cluster_ca        = aws_eks_cluster.main.certificate_authority[0].data
-    enable_ssm_access = var.enable_ssm_access
-  }))
+  # user_data intentionally removed to use AL2023 default bootstrap (nodeadm)
+  # See: https://aws.amazon.com/blogs/containers/amazon-eks-optimized-amazon-linux-2023-amis-now-available/
 
   # Instance metadata options
   metadata_options {

--- a/variables.tf
+++ b/variables.tf
@@ -83,7 +83,7 @@ variable "enable_node_group_limited_admin" {
 variable "eks_cluster_version" {
   description = "EKS cluster version"
   type        = string
-  default     = "1.30" # stable version
+  default     = "1.33" # stable version
 }
 
 variable "eks_node_groups" {
@@ -104,7 +104,7 @@ variable "eks_node_groups" {
       max_size       = 2
       desired_size   = 1
       disk_size      = 20
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64"
       capacity_type  = "SPOT"
     },
     "compute" = {
@@ -113,7 +113,7 @@ variable "eks_node_groups" {
       max_size       = 2
       desired_size   = 1
       disk_size      = 20
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64"
       capacity_type  = "SPOT"
     }
   }


### PR DESCRIPTION
## ✨ 변경 내용
- EKS 클러스터의 AMI 타입을 AL2_x86_64에서 AL2023_x86_64로 변경하고, user_data를 기본 부트스트랩으로 대체
---

## 📌 관련 이슈
- resolved: #54 
---

## ✅ 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---

## 💬 기타 사항
-
