### PR TITLE
feat: EKS 노드 그룹의 AMI 타입을 AL2023_x86_64_STANDARD로 변경

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -104,7 +104,7 @@ variable "eks_node_groups" {
       max_size       = 2
       desired_size   = 1
       disk_size      = 20
-      ami_type       = "AL2023_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       capacity_type  = "SPOT"
     },
     "compute" = {
@@ -113,7 +113,7 @@ variable "eks_node_groups" {
       max_size       = 2
       desired_size   = 1
       disk_size      = 20
-      ami_type       = "AL2023_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       capacity_type  = "SPOT"
     }
   }


### PR DESCRIPTION
## ✨ 변경 내용
- EKS 노드 그룹의 AMI 타입을 AL2023_x86_64_STANDARD로 변경

---

## 📌 관련 이슈
- resolved: #이슈번호

---

## ✅ 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---

## 💬 기타 사항
-
