### PR TITLE
feat: AWS Load Balancer Controller Helm 차트 버전을 1.6.1에서 1.13.4로 업데이트

### DIFF
--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -314,7 +314,7 @@ resource "helm_release" "aws_load_balancer_controller" {
   name       = "aws-load-balancer-controller"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-load-balancer-controller"
-  version    = "1.6.1"
+  version    = "1.13.4"
   namespace  = "kube-system"
   timeout    = 900 # 15분으로 타임아웃 증가
 


### PR DESCRIPTION
## ✨ 변경 내용
- AWS Load Balancer Controller Helm 차트 버전을 1.6.1에서 1.13.4로 업데이트

---

## 📌 관련 이슈
- resolved: #이슈번호

---

## ✅ 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---

## 💬 기타 사항
-
