### PR TITLE
feat: 불필요한 kubernetes_ingress_class_v1 리소스 주석 처리 및 Helm 차트에 의해 관리되도록 변경

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -70,27 +70,6 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/time" {
-  version = "0.13.1"
-  hashes = [
-    "h1:+W+DMrVoVnoXo3f3M4W+OpZbkCrUn6PnqDF33D2Cuf0=",
-    "h1:5l8PAnxPdoUPqNPuv1dAr3efcCCtSCnY+Vj2nSGkQmw=",
-    "h1:ZT5ppCNIModqk3iOkVt5my8b8yBHmDpl663JtXAIRqM=",
-    "zh:02cb9aab1002f0f2a94a4f85acec8893297dc75915f7404c165983f720a54b74",
-    "zh:04429b2b31a492d19e5ecf999b116d396dac0b24bba0d0fb19ecaefe193fdb8f",
-    "zh:26f8e51bb7c275c404ba6028c1b530312066009194db721a8427a7bc5cdbc83a",
-    "zh:772ff8dbdbef968651ab3ae76d04afd355c32f8a868d03244db3f8496e462690",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:898db5d2b6bd6ca5457dccb52eedbc7c5b1a71e4a4658381bcbb38cedbbda328",
-    "zh:8de913bf09a3fa7bedc29fec18c47c571d0c7a3d0644322c46f3aa648cf30cd8",
-    "zh:9402102c86a87bdfe7e501ffbb9c685c32bbcefcfcf897fd7d53df414c36877b",
-    "zh:b18b9bb1726bb8cfbefc0a29cf3657c82578001f514bcf4c079839b6776c47f0",
-    "zh:b9d31fdc4faecb909d7c5ce41d2479dd0536862a963df434be4b16e8e4edc94d",
-    "zh:c951e9f39cca3446c060bd63933ebb89cedde9523904813973fbc3d11863ba75",
-    "zh:e5b773c0d07e962291be0e9b413c7a22c044b8c7b58c76e8aa91d1659990dfb5",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/tls" {
   version = "4.1.0"
   hashes = [

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -303,11 +303,11 @@ resource "aws_security_group_rule" "alb_to_nodes" {
   description              = "Allow ALB to communicate with EKS nodes"
 }
 
-# ingressClass
-resource "kubernetes_ingress_class_v1" "alb" {
-  metadata { name = "alb" }
-  spec { controller = "ingress.k8s.aws/alb" }
-}
+# ingressClass managed by Helm chart (avoid ownership conflicts)
+# resource "kubernetes_ingress_class_v1" "alb" {
+#   metadata { name = "alb" }
+#   spec { controller = "ingress.k8s.aws/alb" }
+# }
 
 # AWS Load Balancer Controller Helm Chart
 resource "helm_release" "aws_load_balancer_controller" {


### PR DESCRIPTION
## ✨ 변경 내용
- 불필요한 kubernetes_ingress_class_v1 리소스 주석 처리 및 Helm 차트에 의해 관리되도록 변경
- 설치강화 하려고 부여했던게 conflict 나는것같아 제거합니다 

---

## 📌 관련 이슈
- resolved: #이슈번호

---

## ✅ 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---

## 💬 기타 사항
-
