### PR TITLE
fix : outputs.tf 파일에 Kubernetes Secrets 생성 상태 출력 값에 대해 민감한 정보로 설정

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -47,6 +47,7 @@ output "backend_api_irsa_role_arn" {
 
 output "kubernetes_secrets_status" {
   description = "Kubernetes Secrets creation status"
+  sensitive   = true
   value = {
     dev_namespace    = module.kubernetes_secrets_dev.namespace_name
     prod_namespace   = module.kubernetes_secrets_prod.namespace_name


### PR DESCRIPTION
## ✨ 변경 내용
- outputs.tf 파일에 Kubernetes Secrets 생성 상태 출력 값에 대해 민감한 정보로 설정

---

## 📌 관련 이슈
- resolved: #이슈번호

---

## ✅ 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---

## 💬 기타 사항
-
