### PR TITLE
feat: ACM 인증서 모듈에서 provider 설정을 외부에서 전달받도록 수정 및 main.tf에서 provider 명시 추가

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -254,14 +254,16 @@ module "cloudfront_prod" {
 
 # ACM for ALB/EKS in ap-northeast-2 (wildcard)
 module "acm_cert_kor" {
-  source = "./modules/acm_certificate"
-  # default provider (ap-northeast-2)
+  source    = "./modules/acm_certificate"
+  providers = { aws = aws }  # 기본 provider (ap-northeast-2)
+
   domain_name               = var.domain_name
   subject_alternative_names = ["*.${var.domain_name}", "dev.api.${var.domain_name}", "argocd.${var.domain_name}"]
 }
 
 module "acm_kor_dns_validation" {
-  source = "./modules/acm_dns_validation"
+  source    = "./modules/acm_dns_validation"
+  providers = { aws = aws }  # 기본 provider (ap-northeast-2)
 
   certificate_arn                       = module.acm_cert_kor.certificate_arn
   zone_id                               = aws_route53_zone.main.zone_id

--- a/modules/acm_certificate/main.tf
+++ b/modules/acm_certificate/main.tf
@@ -7,14 +7,8 @@ terraform {
   }
 }
 
-#ACM 인증서 요청
-provider "aws" {
-  alias  = "virginia"
-  region = "us-east-1"
-}
-
+# ACM 인증서 요청 (provider는 외부에서 전달받음)
 resource "aws_acm_certificate" "cert" {
-  provider          = aws
   domain_name       = var.domain_name
   validation_method = "DNS"
 


### PR DESCRIPTION
## ✨ 변경 내용
- ACM 인증서 모듈에서 provider 설정을 외부에서 전달받도록 수정 및 main.tf에서 provider 명시 추가
(us-east설정만 하드코딩으로 들어가있었음)

---

## 📌 관련 이슈
- resolved: #이슈번호

---

## ✅ 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---

## 💬 기타 사항
-
