### PR TITLE
fix: main.tf 파일에서 ACM 인증서 모듈 이름을 'acm_cert'에서 'acm_cert_kor'로 변경

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -577,7 +577,7 @@ module "alb" {
   depends_on = [
     module.eks,
     module.vpc,
-    module.acm_cert
+    module.acm_cert_kor
   ]
 }
 


### PR DESCRIPTION
## ✨ 변경 내용
- ACM 인증 관련 변경

---

## 📌 관련 이슈
- resolved: #이슈번호

---

## ✅ 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---

## 💬 기타 사항
-
