### PR TITLE
[Feature] External DNS 구성 및 Prometheus/Grafana 모니터링 개선

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -499,7 +499,7 @@ module "elasticache" {
   security_group_ids = [module.vpc.elasticache_sg_id]
   node_type          = "cache.t3.micro"
   num_cache_nodes    = 1
-  redis_auth_token   = var.redis_auth_token
+  # redis_auth_token   = var.redis_auth_token
   tags        = var.common_tags
   depends_on         = [module.eks]
 }

--- a/main.tf
+++ b/main.tf
@@ -122,9 +122,9 @@ module "rds" {
 }
 
 module "db_init" {
-  count  = var.enable_k8s_addons ? 1 : 0
+  count  = var.enable_k8s_addons ? 1 : 1
   source    = "./modules/db_init"
-  enabled = var.enable_k8s_addons
+  enabled = true # var.enable_k8s_addons
 
   namespace = "backend-dev"                        # Job을 어디서 돌릴지
   app_suffix= "backend"

--- a/main.tf
+++ b/main.tf
@@ -606,6 +606,21 @@ resource "aws_security_group_rule" "allow_alb_to_nodes_argo_http_80" {
   ]
 }
 
+resource "aws_security_group_rule" "allow_alb_to_nodes_argo_target_8080" {
+  type                     = "ingress"
+  description              = "Allow ALB to reach ArgoCD pod via NodePort/TargetPort 8080"
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+  security_group_id        = module.eks.node_group_security_group_id
+  source_security_group_id = module.alb.alb_security_group_id
+
+  depends_on = [
+    module.alb,
+    module.eks
+  ]
+}
+
 # ALB → EKS NodeGroup SG: TLS(443) 허용
 resource "aws_security_group_rule" "allow_alb_to_nodes_tls_443" {
   type                     = "ingress"

--- a/main.tf
+++ b/main.tf
@@ -500,7 +500,7 @@ module "elasticache" {
   node_type          = "cache.t3.micro"
   num_cache_nodes    = 1
   redis_auth_token   = var.redis_auth_token
-  common_tags        = var.common_tags
+  tags        = var.common_tags
   depends_on         = [module.eks]
 }
 

--- a/modules/argocd/main.tf
+++ b/modules/argocd/main.tf
@@ -24,7 +24,7 @@ resource "helm_release" "argocd" {
             "alb.ingress.kubernetes.io/scheme"           = "internet-facing"
             "alb.ingress.kubernetes.io/target-type"      = "ip"
             "alb.ingress.kubernetes.io/listen-ports"     = jsonencode([{ HTTP = 80 }, { HTTPS = 443 }])
-            "alb.ingress.kubernetes.io/ssl-redirect"     = "443"
+            # "alb.ingress.kubernetes.io/ssl-redirect"     = "443"
             "alb.ingress.kubernetes.io/certificate-arn"  = var.certificate_arn
             "alb.ingress.kubernetes.io/backend-protocol" = "HTTP"
             "alb.ingress.kubernetes.io/healthcheck-path" = "/healthz"

--- a/modules/db_init/db_init.sql
+++ b/modules/db_init/db_init.sql
@@ -1,0 +1,13 @@
+-- Exporter 유저 생성 & 권한 (비밀번호/유저명은 placeholder)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${exporter_user}') THEN
+    EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', '${exporter_user}', '${exporter_password}');
+  END IF;
+END $$;
+
+GRANT pg_monitor TO "${exporter_user}";
+GRANT CONNECT ON DATABASE "${db_name}" TO "${exporter_user}";
+
+-- pgvector 설치 (idempotent)
+CREATE EXTENSION IF NOT EXISTS vector;

--- a/modules/db_init/main.tf
+++ b/modules/db_init/main.tf
@@ -1,28 +1,6 @@
 locals {
   # SQL에 비밀값(계정/비밀번호) 직접 넣지 말고 Flyway placeholder만 둠
-  v1_init_sql = coalesce(
-    var.sql_init,
-    <<-SQL
-    -- Exporter 유저 생성 & 권한 (비밀번호/유저명은 placeholder)
-    DO $$
-    BEGIN
-      IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${exporter_user}') THEN
-        EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', '${exporter_user}', '${exporter_password}');
-      END IF;
-    END $$;
-
-    GRANT pg_monitor TO "${exporter_user}";
-    GRANT CONNECT ON DATABASE "${db_name}" TO "${exporter_user}";
-    SQL
-  )
-
-  v2_pgvector_sql = coalesce(
-    var.sql_pgvector,
-    <<-SQL
-    -- pgvector 설치 (idempotent)
-    CREATE EXTENSION IF NOT EXISTS vector;
-    SQL
-  )
+    db_init_sql = file("${path.module}/db_init.sql")
 
   # Job 이름은 환경에 따라 유니크하게
   job_name = var.job_name != "" ? var.job_name : "flyway-init-${var.app_suffix}"
@@ -38,8 +16,7 @@ resource "kubernetes_config_map" "flyway_sql" {
   }
 
   data = {
-    "V1__init.sql"     = local.v1_init_sql
-    "V2__pgvector.sql" = local.v2_pgvector_sql
+    "V1__init.sql"     = local.db_init_sql
   }
 }
 

--- a/modules/db_init/main.tf
+++ b/modules/db_init/main.tf
@@ -54,15 +54,13 @@ resource "kubernetes_secret" "flyway_db" {
 
   type = "Opaque"
   data = {
-    DB_HOST           = base64encode(var.db_host)
-    DB_PORT           = base64encode(var.db_port)
-    DB_NAME           = base64encode(var.db_name)
-    DB_USER           = base64encode(var.db_user)
-    DB_PASSWORD       = base64encode(var.db_password)
-
-    # placeholder 값도 전부 Secret로 주입
-    EXPORTER_USER     = base64encode(var.exporter_user)
-    EXPORTER_PASSWORD = base64encode(var.exporter_password)
+    DB_HOST           = var.db_host
+    DB_PORT           = var.db_port
+    DB_NAME           = var.db_name
+    DB_USER           = var.db_user
+    DB_PASSWORD       = var.db_password
+    EXPORTER_USER     = var.exporter_user
+    EXPORTER_PASSWORD = var.exporter_password
   }
 }
 
@@ -117,7 +115,7 @@ resource "kubernetes_manifest" "flyway_job" {
               args = [<<-EOT
                 set -e
                 flyway \
-                  -url=jdbc:postgresql://$${DB_HOST}:$${DB_PORT}/$${DB_NAME}?sslmode=require \
+                  -url=jdbc:postgresql://$${DB_HOST}:$${DB_PORT}/$${DB_NAME} \
                   -user=$${DB_USER} -password=$${DB_PASSWORD} \
                   -locations=filesystem:/flyway/sql \
                   -placeholders.exporter_user=$${EXPORTER_USER} \

--- a/modules/db_init/main.tf
+++ b/modules/db_init/main.tf
@@ -149,31 +149,31 @@ resource "kubernetes_manifest" "flyway_job" {
   }
 }
 
-resource "null_resource" "wait_for_flyway_job" {
-  count = var.enabled ? 1 : 0
+# resource "null_resource" "wait_for_flyway_job" {
+#   count = var.enabled ? 1 : 0
 
-  provisioner "local-exec" {
-    command = <<EOT
-      #!/bin/bash
-      set -e
+#   provisioner "local-exec" {
+#     command = <<EOT
+#       #!/bin/bash
+#       set -e
 
-      echo "[INFO] Waiting for Flyway job to complete..."
+#       echo "[INFO] Waiting for Flyway job to complete..."
 
-      for i in {1..30}; do
-        status=$(kubectl -n ${var.namespace} get job ${local.job_name} -o jsonpath='{.status.succeeded}' || echo "0")
-        if [ "$status" == "1" ]; then
-          echo "[INFO] Flyway job completed successfully."
-          exit 0
-        fi
-        echo "[INFO] Waiting for job... ($i/30)"
-        sleep 10
-      done
+#       for i in {1..30}; do
+#         status=$(kubectl -n ${var.namespace} get job ${local.job_name} -o jsonpath='{.status.succeeded}' || echo "0")
+#         if [ "$status" == "1" ]; then
+#           echo "[INFO] Flyway job completed successfully."
+#           exit 0
+#         fi
+#         echo "[INFO] Waiting for job... ($i/30)"
+#         sleep 10
+#       done
 
-      echo "[ERROR] Timeout waiting for Flyway job to succeed"
-      exit 1
-    EOT
-    interpreter = ["/bin/bash", "-c"]
-  }
+#       echo "[ERROR] Timeout waiting for Flyway job to succeed"
+#       exit 1
+#     EOT
+#     interpreter = ["/bin/bash", "-c"]
+#   }
 
-  depends_on = [kubernetes_manifest.flyway_job]
-}
+#   depends_on = [kubernetes_manifest.flyway_job]
+# }

--- a/modules/db_init/main.tf
+++ b/modules/db_init/main.tf
@@ -148,3 +148,32 @@ resource "kubernetes_manifest" "flyway_job" {
     ]
   }
 }
+
+resource "null_resource" "wait_for_flyway_job" {
+  count = var.enabled ? 1 : 0
+
+  provisioner "local-exec" {
+    command = <<EOT
+      #!/bin/bash
+      set -e
+
+      echo "[INFO] Waiting for Flyway job to complete..."
+
+      for i in {1..30}; do
+        status=$(kubectl -n ${var.namespace} get job ${local.job_name} -o jsonpath='{.status.succeeded}' || echo "0")
+        if [ "$status" == "1" ]; then
+          echo "[INFO] Flyway job completed successfully."
+          exit 0
+        fi
+        echo "[INFO] Waiting for job... ($i/30)"
+        sleep 10
+      done
+
+      echo "[ERROR] Timeout waiting for Flyway job to succeed"
+      exit 1
+    EOT
+    interpreter = ["/bin/bash", "-c"]
+  }
+
+  depends_on = [kubernetes_manifest.flyway_job]
+}

--- a/modules/db_init/main.tf
+++ b/modules/db_init/main.tf
@@ -6,13 +6,13 @@ locals {
     -- Exporter 유저 생성 & 권한 (비밀번호/유저명은 placeholder)
     DO $$
     BEGIN
-      IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '$${exporter_user}') THEN
-        EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', '$${exporter_user}', '$${exporter_password}');
+      IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${exporter_user}') THEN
+        EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', '${exporter_user}', '${exporter_password}');
       END IF;
     END $$;
 
-    GRANT pg_monitor TO "$${exporter_user}";
-    GRANT CONNECT ON DATABASE "$${db_name}" TO "$${exporter_user}";
+    GRANT pg_monitor TO "${exporter_user}";
+    GRANT CONNECT ON DATABASE "${db_name}" TO "${exporter_user}";
     SQL
   )
 

--- a/modules/documentdb/main.tf
+++ b/modules/documentdb/main.tf
@@ -3,7 +3,7 @@ resource "aws_docdb_cluster" "this" {
   # 기본 설정
   cluster_identifier = "${var.project_name}-${var.environment}-docdb" # 클러스터 식별자
   engine             = "docdb"                                        # DocumentDB 엔진
-  engine_version     = "4.11.1"
+  engine_version     = "4.0.0"
 
   # 인증 정보
   master_username = var.db_username
@@ -50,7 +50,7 @@ resource "aws_docdb_cluster_instance" "this" {
 
 # Parameter Group
 resource "aws_docdb_cluster_parameter_group" "this" {
-  family = "docdb5.0" # DocumentDB 버전 패밀리
+  family = "docdb4.0" # DocumentDB 버전 패밀리
   name   = "${var.project_name}-${var.environment}-docdb-params"
 
   parameter {

--- a/modules/documentdb/main.tf
+++ b/modules/documentdb/main.tf
@@ -3,7 +3,7 @@ resource "aws_docdb_cluster" "this" {
   # 기본 설정
   cluster_identifier = "${var.project_name}-${var.environment}-docdb" # 클러스터 식별자
   engine             = "docdb"                                        # DocumentDB 엔진
-  engine_version     = "5.0.0"
+  engine_version     = "4.11.1"
 
   # 인증 정보
   master_username = var.db_username

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -380,6 +380,17 @@ resource "aws_security_group" "node_group" {
   }
 }
 
+# Allow DNS UDP 53 for CoreDNS name resolution
+resource "aws_security_group_rule" "nodegroup_allow_dns_udp_53" {
+  type              = "ingress"
+  from_port         = 53
+  to_port           = 53
+  protocol          = "udp"
+  security_group_id = aws_security_group.node_group.id
+  cidr_blocks       = [var.vpc_cidr] # 또는 필요한 범위로 제한
+  description       = "Allow DNS (UDP 53) for CoreDNS"
+}
+
 # Security group rules for cluster to communicate with nodes
 resource "aws_security_group_rule" "cluster_to_node" {
   type                     = "ingress"

--- a/modules/elasticache/main.tf
+++ b/modules/elasticache/main.tf
@@ -30,7 +30,7 @@ resource "aws_elasticache_replication_group" "this" {
 
   # 권장 보안 옵션
   at_rest_encryption_enabled = true
-  transit_encryption_enabled = true
+  transit_encryption_enabled = false
 
   tags = var.tags
 }

--- a/modules/elasticache/main.tf
+++ b/modules/elasticache/main.tf
@@ -26,7 +26,7 @@ resource "aws_elasticache_replication_group" "this" {
   security_group_ids      = var.security_group_ids
 
   # Redis AUTH
-  auth_token = var.redis_auth_token
+  # auth_token = var.redis_auth_token
 
   # 권장 보안 옵션
   at_rest_encryption_enabled = true

--- a/modules/elasticache/main.tf
+++ b/modules/elasticache/main.tf
@@ -9,7 +9,7 @@ resource "aws_elasticache_subnet_group" "this" {
   name       = "${var.project_name}-${var.environment}-elasticache-subnet-group"
   subnet_ids = var.subnet_ids
 
-  tags = var.common_tags
+  tags = var.tags
 }
 
 # Redis Replication Group
@@ -32,5 +32,5 @@ resource "aws_elasticache_replication_group" "this" {
   at_rest_encryption_enabled = true
   transit_encryption_enabled = true
 
-  tags = var.common_tags
+  tags = var.tags
 }

--- a/modules/elasticache/variables.tf
+++ b/modules/elasticache/variables.tf
@@ -26,7 +26,7 @@ variable "num_cache_nodes" {
   default     = 1
 }
 
-variable "common_tags" {
+variable "tags" {
   type = map(string)
 }
 

--- a/modules/elasticache/variables.tf
+++ b/modules/elasticache/variables.tf
@@ -30,11 +30,11 @@ variable "tags" {
   type = map(string)
 }
 
-variable "redis_auth_token" {
-  description = "Redis AUTH token (min 16 characters)"
-  type        = string
-  sensitive   = true
-}
+# variable "redis_auth_token" {
+#   description = "Redis AUTH token (min 16 characters)"
+#   type        = string
+#   sensitive   = true
+# }
 
 # variable "security_group_ids" {
 #   description = "List of security group IDs to assign to Elasticache"

--- a/modules/external_dns/main.tf
+++ b/modules/external_dns/main.tf
@@ -110,17 +110,19 @@ resource "helm_release" "external_dns" {
   recreate_pods     = false       # ✅ 파드 재시작 보장
 
   # ServiceAccount: IRSA로 만든 SA 재사용
-  set {
-    name  = "serviceAccount.create"
-    value = "false"
-  }
-  set {
-    name  = "serviceAccount.name"
-    value = kubernetes_service_account.externaldns.metadata[0].name
-  }
+  # set {
+  #   name  = "serviceAccount.create"
+  #   value = "false"
+  # }
+  # set {
+  #   name  = "serviceAccount.name"
+  #   value = kubernetes_service_account.externaldns.metadata[0].name
+  # }
 
   values = [
     yamlencode({
+      automountServiceAccountToken = true
+
       provider          = "aws"
       policy            = var.policy
       registry          = var.registry
@@ -129,6 +131,15 @@ resource "helm_release" "external_dns" {
       interval          = "2m"
       triggerLoopOnEvent= true
       logLevel          = "info"
+
+      # SA 재사용 + IRSA (차트에도 동일 값 명시해서 null 방지)
+      serviceAccount = {
+        create                       = false
+        name                         = kubernetes_service_account.externaldns.metadata[0].name
+        automountServiceAccountToken = true
+      }
+
+      rbac = { create = true }
 
       # annotationFilter는 values의 정식 키로 안전하게 전달
       annotationFilter  = "external-dns.goteego/enabled in (true, 'true')"

--- a/modules/monitoring/grafana/dashboards/jvm-service.json
+++ b/modules/monitoring/grafana/dashboards/jvm-service.json
@@ -9,7 +9,7 @@
         "name": "pod",
         "type": "query",
         "datasource": "Prometheus",
-        "query": "label_values(jvm_memory_used_bytes{namespace=\"backend-dev\", phase=\"Running\", pod!~\"flyway.*\"}, pod)",
+        "query": "label_values(kube_pod_status_phase{namespace=\"backend-dev\", phase=\"Running\", pod!~\"flyway.*\"}, pod)",
         "includeAll": false,
         "multi": false
       }

--- a/modules/monitoring/grafana/dashboards/jvm-service.json
+++ b/modules/monitoring/grafana/dashboards/jvm-service.json
@@ -9,7 +9,7 @@
         "name": "pod",
         "type": "query",
         "datasource": "Prometheus",
-        "query": "label_values(kube_pod_status_phase{namespace=\"backend-dev\", phase=\"Running\", pod!~\"flyway.*\"} == 1, pod)",
+        "query": "label_values(jvm_memory_used_bytes{namespace=\"backend-dev\", phase=\"Running\", pod!~\"flyway.*\"}, pod)",
         "includeAll": false,
         "multi": false
       }

--- a/modules/monitoring/grafana/dashboards/jvm-service.json
+++ b/modules/monitoring/grafana/dashboards/jvm-service.json
@@ -1,23 +1,15 @@
 {
   "title": "JVM Service Overview",
   "schemaVersion": 38,
-  "version": 2,
+  "version": 3,
   "timezone": "browser",
   "templating": {
     "list": [
       {
-        "name": "namespace",
-        "type": "query",
-        "datasource": "Prometheus",
-        "query": "label_values(kube_pod_info, namespace)",
-        "includeAll": false,
-        "multi": false
-      },
-      {
         "name": "pod",
         "type": "query",
         "datasource": "Prometheus",
-        "query": "label_values(kube_pod_info{namespace=\"$namespace\"}, pod)",
+        "query": "label_values(kube_pod_status_phase{namespace=\"backend-dev\", phase=\"Running\"}, pod)",
         "includeAll": false,
         "multi": false
       }
@@ -44,7 +36,7 @@
       },
       "targets": [
         {
-          "expr": "jvm_memory_used_bytes{area=\"heap\",namespace=\"$namespace\",pod=\"$pod\"} / 1024 / 1024",
+          "expr": "max(jvm_memory_used_bytes{area=\"heap\",namespace=\"backend-dev\",pod=\"$pod\"}) / 1024 / 1024",
           "refId": "A"
         }
       ]
@@ -69,7 +61,7 @@
       },
       "targets": [
         {
-          "expr": "rate(jvm_gc_pause_seconds_sum{namespace=\"$namespace\",pod=\"$pod\"}[$__rate_interval]) * 1000",
+          "expr": "rate(jvm_gc_pause_seconds_sum{namespace=\"backend-dev\",pod=\"$pod\"}[$__rate_interval]) * 1000",
           "refId": "A"
         }
       ]
@@ -94,7 +86,7 @@
       },
       "targets": [
         {
-          "expr": "rate(process_cpu_seconds_total{namespace=\"$namespace\",pod=\"$pod\"}[$__rate_interval])",
+          "expr": "max(process_cpu_usage{namespace=\"backend-dev\",pod=\"$pod\"})",
           "refId": "A"
         }
       ]
@@ -107,7 +99,7 @@
       "fieldConfig": { "defaults": { "unit": "reqps" } },
       "targets": [
         {
-          "expr": "sum(rate(http_server_requests_seconds_count{namespace=\"$namespace\",pod=\"$pod\"}[$__rate_interval]))",
+          "expr": "sum(rate(http_server_requests_seconds_count{namespace=\"backend-dev\",pod=\"$pod\"}[$__rate_interval]))",
           "refId": "A"
         }
       ]
@@ -132,7 +124,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(http_server_requests_seconds_count{status=~\"5..\",namespace=\"$namespace\",pod=\"$pod\"}[$__rate_interval]))",
+          "expr": "sum(rate(http_server_requests_seconds_count{status=~\"5..\",namespace=\"backend-dev\",pod=\"$pod\"}[$__rate_interval]))",
           "refId": "A"
         }
       ]
@@ -144,7 +136,7 @@
       "datasource": "Prometheus",
       "targets": [
         {
-          "expr": "jvm_memory_used_bytes{area=\"heap\",namespace=\"$namespace\",pod=\"$pod\"}",
+          "expr": "jvm_memory_used_bytes{area=\"heap\",namespace=\"backend-dev\",pod=\"$pod\"}",
           "refId": "A"
         }
       ]
@@ -156,7 +148,7 @@
       "datasource": "Prometheus",
       "targets": [
         {
-          "expr": "jvm_threads_current{namespace=\"$namespace\",pod=\"$pod\"}",
+          "expr": "jvm_threads_current{namespace=\"backend-dev\",pod=\"$pod\"}",
           "refId": "A"
         }
       ]
@@ -168,7 +160,7 @@
       "datasource": "Prometheus",
       "targets": [
         {
-          "expr": "rate(jvm_gc_pause_seconds_sum{namespace=\"$namespace\",pod=\"$pod\"}[$__rate_interval])",
+          "expr": "rate(jvm_gc_pause_seconds_sum{namespace=\"backend-dev\",pod=\"$pod\"}[$__rate_interval])",
           "refId": "A"
         }
       ]
@@ -180,7 +172,7 @@
       "datasource": "Prometheus",
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{namespace=\"$namespace\",pod=\"$pod\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{namespace=\"backend-dev\",pod=\"$pod\"}[$__rate_interval])))",
           "refId": "A"
         }
       ]
@@ -192,7 +184,7 @@
       "datasource": "Prometheus",
       "targets": [
         {
-          "expr": "rate(process_cpu_seconds_total{namespace=\"$namespace\",pod=\"$pod\"}[$__rate_interval])",
+          "expr": "rate(process_cpu_seconds_total{namespace=\"backend-dev\",pod=\"$pod\"}[$__rate_interval])",
           "refId": "A"
         }
       ]

--- a/modules/monitoring/grafana/dashboards/jvm-service.json
+++ b/modules/monitoring/grafana/dashboards/jvm-service.json
@@ -9,7 +9,7 @@
         "name": "pod",
         "type": "query",
         "datasource": "Prometheus",
-        "query": "label_values(kube_pod_status_phase{namespace=\"backend-dev\", phase=\"Running\"}, pod)",
+        "query": "label_values(kube_pod_status_phase{namespace=\"backend-dev\", phase=\"Running\", pod!~\"flyway.*\"} == 1, pod)",
         "includeAll": false,
         "multi": false
       }

--- a/modules/monitoring/grafana/main.tf
+++ b/modules/monitoring/grafana/main.tf
@@ -16,20 +16,20 @@ resource "helm_release" "grafana" {
           "alb.ingress.kubernetes.io/security-groups" = var.alb_security_group_id
         }
       }
-      datasources = {
-        "datasources.yaml" = {
-          apiVersion = 1
-          datasources = [
-            {
-              name      = "Prometheus"
-              type      = "prometheus"
-              url       = "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"
-              access    = "proxy"
-              isDefault = true
-            }
-          ]
-        }
-      }
+      # datasources = {
+      #   "datasources.yaml" = {
+      #     apiVersion = 1
+      #     datasources = [
+      #       {
+      #         name      = "Prometheus"
+      #         type      = "prometheus"
+      #         url       = "http://kube-prometheus-stack-prometheus:9090"
+      #         access    = "proxy"
+      #         isDefault = true
+      #       }
+      #     ]
+      #   }
+      # }
     })
   ]
 

--- a/modules/monitoring/grafana/values.yaml
+++ b/modules/monitoring/grafana/values.yaml
@@ -52,6 +52,10 @@ grafana:
           options:
             path: /var/lib/grafana/dashboards/default
 
+  grafana.ini:
+    security:
+      admin_api_enabled: true
+
   sidecar:
     dashboards:
       enabled: true
@@ -59,5 +63,8 @@ grafana:
       labelValue: "1"
       searchNamespace: "monitoring"
       folder: /var/lib/grafana/dashboards/default
+      env:
+        - name: GF_SECURITY_ADMIN_API_ENABLED
+          value: "true"
 
   dashboardsConfigMaps: []

--- a/modules/monitoring/grafana/values.yaml
+++ b/modules/monitoring/grafana/values.yaml
@@ -32,7 +32,7 @@ datasources:
     datasources:
       - name: Prometheus
         type: prometheus
-        url: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+        url: http://kube-prometheus-stack-prometheus:9090
         access: proxy
         isDefault: true
 

--- a/modules/monitoring/grafana/values.yaml
+++ b/modules/monitoring/grafana/values.yaml
@@ -1,64 +1,63 @@
-service:
-  type: ClusterIP
+grafana:
+  service:
+    type: ClusterIP
 
-ingress:
-  enabled: true
-  ingressClassName: alb
-  annotations:
-    alb.ingress.kubernetes.io/scheme: "internet-facing"
-    alb.ingress.kubernetes.io/target-type: "ip"
-    alb.ingress.kubernetes.io/backend-protocol: "HTTP"
-    alb.ingress.kubernetes.io/group.name: "monitoring"
-    alb.ingress.kubernetes.io/healthcheck-path: "/login"
-    alb.ingress.kubernetes.io/success-codes: "200-399"
-    alb.ingress.kubernetes.io/healthcheck-port: "traffic-port"
-
-    external-dns.goteego/enabled: "true"
-  hosts:
-    - grafana.goteego.store # ← 문자열 리스트!
-  path: /
-  pathType: Prefix
-  tls: [] # 추후 HTTPS 시 ACM 연결
-
-podDnsPolicy: ClusterFirst
-podDnsConfig:
-  options:
-    - name: ndots
-      value: "1"
-
-datasources:
-  datasources.yaml:
-    apiVersion: 1
-    datasources:
-      - name: Prometheus
-        type: prometheus
-        url: http://kube-prometheus-stack-prometheus:9090
-        access: proxy
-        isDefault: true
-
-persistence:
-  enabled: false
-
-dashboardProviders:
-  dashboardproviders.yaml:
-    apiVersion: 1
-    providers:
-      - name: "default"
-        orgId: 1
-        folder: ""
-        type: file
-        disableDeletion: false
-        editable: true
-        options:
-          path: /var/lib/grafana/dashboards/default
-
-# 사이드카가 ConfigMap(라벨: grafana_dashboard=1)을 자동으로 읽어 대시보드 로드
-sidecar:
-  dashboards:
+  ingress:
     enabled: true
-    label: grafana_dashboard
-    labelValue: "1"
-    searchNamespace: "monitoring"
-    folder: /var/lib/grafana/dashboards/default
+    ingressClassName: alb
+    annotations:
+      alb.ingress.kubernetes.io/scheme: "internet-facing"
+      alb.ingress.kubernetes.io/target-type: "ip"
+      alb.ingress.kubernetes.io/backend-protocol: "HTTP"
+      alb.ingress.kubernetes.io/group.name: "monitoring"
+      alb.ingress.kubernetes.io/healthcheck-path: "/login"
+      alb.ingress.kubernetes.io/success-codes: "200-399"
+      alb.ingress.kubernetes.io/healthcheck-port: "traffic-port"
+      external-dns.goteego/enabled: "true"
+    hosts:
+      - grafana.goteego.store
+    path: /
+    pathType: Prefix
+    tls: []
 
-dashboardsConfigMaps: []
+  podDnsPolicy: ClusterFirst
+  podDnsConfig:
+    options:
+      - name: ndots
+        value: "1"
+
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: Prometheus
+          type: prometheus
+          url: http://kube-prometheus-stack-prometheus:9090
+          access: proxy
+          isDefault: true
+
+  persistence:
+    enabled: false
+
+  dashboardProviders:
+    dashboardproviders.yaml:
+      apiVersion: 1
+      providers:
+        - name: "default"
+          orgId: 1
+          folder: ""
+          type: file
+          disableDeletion: false
+          editable: true
+          options:
+            path: /var/lib/grafana/dashboards/default
+
+  sidecar:
+    dashboards:
+      enabled: true
+      label: grafana_dashboard
+      labelValue: "1"
+      searchNamespace: "monitoring"
+      folder: /var/lib/grafana/dashboards/default
+
+  dashboardsConfigMaps: []

--- a/modules/monitoring/grafana/values.yaml
+++ b/modules/monitoring/grafana/values.yaml
@@ -1,30 +1,38 @@
+ingress:
+  enabled: true
+  ingressClassName: alb
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: "internet-facing"
+    alb.ingress.kubernetes.io/target-type: "ip"
+    alb.ingress.kubernetes.io/backend-protocol: "HTTP"
+    alb.ingress.kubernetes.io/group.name: "monitoring"
+    alb.ingress.kubernetes.io/healthcheck-path: "/login"
+    alb.ingress.kubernetes.io/success-codes: "200-399"
+    alb.ingress.kubernetes.io/healthcheck-port: "traffic-port"
+    external-dns.alpha.kubernetes.io/hostname: grafana.goteego.store
+  hosts:
+    - grafana.goteego.store
+  path: /
+  pathType: Prefix
+  tls: []
+
 grafana:
   service:
     type: ClusterIP
-
-  ingress:
-    enabled: true
-    ingressClassName: alb
-    annotations:
-      alb.ingress.kubernetes.io/scheme: "internet-facing"
-      alb.ingress.kubernetes.io/target-type: "ip"
-      alb.ingress.kubernetes.io/backend-protocol: "HTTP"
-      alb.ingress.kubernetes.io/group.name: "monitoring"
-      alb.ingress.kubernetes.io/healthcheck-path: "/login"
-      alb.ingress.kubernetes.io/success-codes: "200-399"
-      alb.ingress.kubernetes.io/healthcheck-port: "traffic-port"
-      external-dns.goteego/enabled: "true"
-    hosts:
-      - grafana.goteego.store
-    path: /
-    pathType: Prefix
-    tls: []
 
   podDnsPolicy: ClusterFirst
   podDnsConfig:
     options:
       - name: ndots
         value: "1"
+
+  persistence:
+    enabled: false
+
+  grafana.ini:
+    security:
+      admin_api_enabled: true
 
   datasources:
     datasources.yaml:
@@ -35,9 +43,6 @@ grafana:
           url: http://kube-prometheus-stack-prometheus:9090
           access: proxy
           isDefault: true
-
-  persistence:
-    enabled: false
 
   dashboardProviders:
     dashboardproviders.yaml:
@@ -51,10 +56,6 @@ grafana:
           editable: true
           options:
             path: /var/lib/grafana/dashboards/default
-
-  grafana.ini:
-    security:
-      admin_api_enabled: true
 
   sidecar:
     dashboards:

--- a/modules/monitoring/grafana/values.yaml
+++ b/modules/monitoring/grafana/values.yaml
@@ -17,55 +17,54 @@ ingress:
   pathType: Prefix
   tls: []
 
-grafana:
-  service:
-    type: ClusterIP
+service:
+  type: ClusterIP
 
-  podDnsPolicy: ClusterFirst
-  podDnsConfig:
-    options:
-      - name: ndots
-        value: "1"
+podDnsPolicy: ClusterFirst
+podDnsConfig:
+  options:
+    - name: ndots
+      value: "1"
 
-  persistence:
-    enabled: false
+persistence:
+  enabled: false
 
-  grafana.ini:
-    security:
-      admin_api_enabled: true
+grafana.ini:
+  security:
+    admin_api_enabled: true
 
-  datasources:
-    datasources.yaml:
-      apiVersion: 1
-      datasources:
-        - name: Prometheus
-          type: prometheus
-          url: http://kube-prometheus-stack-prometheus:9090
-          access: proxy
-          isDefault: true
+datasources:
+  datasources.yaml:
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        url: http://kube-prometheus-stack-prometheus:9090
+        access: proxy
+        isDefault: true
 
-  dashboardProviders:
-    dashboardproviders.yaml:
-      apiVersion: 1
-      providers:
-        - name: "default"
-          orgId: 1
-          folder: ""
-          type: file
-          disableDeletion: false
-          editable: true
-          options:
-            path: /var/lib/grafana/dashboards/default
+dashboardProviders:
+  dashboardproviders.yaml:
+    apiVersion: 1
+    providers:
+      - name: "default"
+        orgId: 1
+        folder: ""
+        type: file
+        disableDeletion: false
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards/default
 
-  sidecar:
-    dashboards:
-      enabled: true
-      label: grafana_dashboard
-      labelValue: "1"
-      searchNamespace: "monitoring"
-      folder: /var/lib/grafana/dashboards/default
-      env:
-        - name: GF_SECURITY_ADMIN_API_ENABLED
-          value: "true"
+sidecar:
+  dashboards:
+    enabled: true
+    label: grafana_dashboard
+    labelValue: "1"
+    searchNamespace: "monitoring"
+    folder: /var/lib/grafana/dashboards/default
+    env:
+      - name: GF_SECURITY_ADMIN_API_ENABLED
+        value: "true"
 
-  dashboardsConfigMaps: []
+dashboardsConfigMaps: []

--- a/modules/monitoring/prometheus/main.tf
+++ b/modules/monitoring/prometheus/main.tf
@@ -56,9 +56,12 @@ resource "helm_release" "postgres_exporter" {
 
   values = [
     yamlencode({
-      config = {
-      datasource = "postgresql://${var.rds_db_exporter_user}:${var.rds_db_exporter_password}@${var.rds_endpoint}:5432/${var.rds_db_name}?sslmode=disable"
-    }
+      extraEnv = [
+        {
+          name  = "DATA_SOURCE_NAME"
+          value = "postgresql://${var.rds_db_exporter_user}:${var.rds_db_exporter_password}@${var.rds_endpoint}:5432/${var.rds_db_name}?sslmode=disable"
+        }
+      ]
 
       # 민감정보는 Secret에서 주입
       envFromSecret = null# kubernetes_secret.postgres_exporter.metadata[0].name

--- a/modules/monitoring/prometheus/main.tf
+++ b/modules/monitoring/prometheus/main.tf
@@ -36,11 +36,9 @@ resource "kubernetes_secret" "postgres_exporter" {
   type = "Opaque"
 
   data = {
-    DATA_SOURCE_NAME = base64encode(
-      "postgresql://${var.rds_db_exporter_user}:${var.rds_db_exporter_password}@${var.rds_endpoint}:5432/${var.rds_db_name}?sslmode=disable"
-    )   
-    # DATA_SOURCE_USER = base64encode(var.rds_db_exporter_user)
-    # DATA_SOURCE_PASS = base64encode(var.rds_db_exporter_password)
+    DATA_SOURCE_URI  = base64encode("${var.rds_endpoint}:5432/${var.rds_db_name}?sslmode=disable")
+    DATA_SOURCE_USER = base64encode(var.rds_db_exporter_user)
+    DATA_SOURCE_PASS = base64encode(var.rds_db_exporter_password)
   }
 }
 
@@ -56,19 +54,8 @@ resource "helm_release" "postgres_exporter" {
 
   values = [
     yamlencode({
-      config = {
-        datasource = null  # 기본값 무력화
-      }
-
-      extraEnv = [
-        {
-          name  = "DATA_SOURCE_NAME"
-          value = "postgresql://${var.rds_db_exporter_user}:${var.rds_db_exporter_password}@${var.rds_endpoint}:5432/${var.rds_db_name}?sslmode=disable"
-        }
-      ]
-
       # 민감정보는 Secret에서 주입
-      envFromSecret = null# kubernetes_secret.postgres_exporter.metadata[0].name
+      envFromSecret = kubernetes_secret.postgres_exporter.metadata[0].name
 
       # ServiceMonitor를 만들어 kube-prometheus-stack이 자동 스크레이프
       serviceMonitor = {

--- a/modules/monitoring/prometheus/main.tf
+++ b/modules/monitoring/prometheus/main.tf
@@ -21,24 +21,28 @@ resource "helm_release" "prometheus" {
   depends_on = [var.depends_on_module]
 }
 
-########################
-# Postgres Exporter Secret
-########################
-resource "kubernetes_secret" "postgres_exporter" {
+resource "kubernetes_secret" "postgres_exporter_config" {
   metadata {
-    name      = "postgres-exporter-secret"
+    name      = "postgres-exporter-config-secret"
     namespace = var.namespace
-    labels = {
-      "app.kubernetes.io/name" = "postgres-exporter"
-    }
   }
 
   type = "Opaque"
 
   data = {
-    DATA_SOURCE_URI  = base64encode("${var.rds_endpoint}:5432/${var.rds_db_name}?sslmode=disable")
-    DATA_SOURCE_USER = base64encode(var.rds_db_exporter_user)
-    DATA_SOURCE_PASS = base64encode(var.rds_db_exporter_password)
+    "postgres_exporter.yml" = base64encode(yamlencode({
+      global = {
+        scrape_interval = "15s"
+      }
+      datasource = {
+        host     = var.rds_endpoint
+        user     = var.rds_db_exporter_user
+        password = var.rds_db_exporter_password
+        port     = 5432
+        dbname   = var.rds_db_name
+        sslmode  = "disable"
+      }
+    }))
   }
 }
 
@@ -54,15 +58,9 @@ resource "helm_release" "postgres_exporter" {
 
   values = [
     yamlencode({
-      config = {
-        datasource = {
-          host     = var.rds_endpoint
-          port     = "5432"
-          user     = var.rds_db_exporter_user
-          dbname   = var.rds_db_name
-          sslmode  = "disable"
-          password = var.rds_db_exporter_password
-        }
+      existingSecret = {
+        enabled = true
+        name    = kubernetes_secret.postgres_exporter_config.metadata[0].name
       }
       # 민감정보는 Secret에서 주입
       # envFromSecret = kubernetes_secret.postgres_exporter.metadata[0].name
@@ -88,6 +86,27 @@ resource "helm_release" "postgres_exporter" {
 
   depends_on = [
     helm_release.prometheus,
-    kubernetes_secret.postgres_exporter,
+    kubernetes_secret.postgres_exporter_config,
   ]
 }
+
+########################
+# Postgres Exporter Secret
+########################
+# resource "kubernetes_secret" "postgres_exporter" {
+#   metadata {
+#     name      = "postgres-exporter-secret"
+#     namespace = var.namespace
+#     labels = {
+#       "app.kubernetes.io/name" = "postgres-exporter"
+#     }
+#   }
+
+#   type = "Opaque"
+
+#   data = {
+#     DATA_SOURCE_URI  = base64encode("${var.rds_endpoint}:5432/${var.rds_db_name}?sslmode=disable")
+#     DATA_SOURCE_USER = base64encode(var.rds_db_exporter_user)
+#     DATA_SOURCE_PASS = base64encode(var.rds_db_exporter_password)
+#   }
+# }

--- a/modules/monitoring/prometheus/main.tf
+++ b/modules/monitoring/prometheus/main.tf
@@ -36,9 +36,11 @@ resource "kubernetes_secret" "postgres_exporter" {
   type = "Opaque"
 
   data = {
-    # chart가 envFromSecret로 읽어감
-    DATA_SOURCE_USER = base64encode(var.rds_db_exporter_user)
-    DATA_SOURCE_PASS = base64encode(var.rds_db_exporter_password)
+    DATA_SOURCE_NAME = base64encode(
+      "postgresql://${var.rds_db_exporter_user}:${var.rds_db_exporter_password}@${var.rds_endpoint}:5432/${var.rds_db_name}?sslmode=disable"
+    )   
+    # DATA_SOURCE_USER = base64encode(var.rds_db_exporter_user)
+    # DATA_SOURCE_PASS = base64encode(var.rds_db_exporter_password)
   }
 }
 
@@ -58,15 +60,6 @@ resource "helm_release" "postgres_exporter" {
         # 필요 시 고정 버전 사용 가능 (예: "v0.15.0")
         # tag = "v0.15.0"
       }
-
-      # exporter가 사용할 환경변수
-      env = [
-        {
-          name  = "DATA_SOURCE_URI"
-          # RDS 엔드포인트:포트/DB명 + TLS 필수
-          value = "${var.rds_endpoint}:5432/${var.rds_db_name}?sslmode=require"
-        }
-      ]
 
       # 민감정보는 Secret에서 주입
       envFromSecret = kubernetes_secret.postgres_exporter.metadata[0].name

--- a/modules/monitoring/prometheus/main.tf
+++ b/modules/monitoring/prometheus/main.tf
@@ -59,17 +59,12 @@ resource "helm_release" "postgres_exporter" {
       env = [
         {
           name  = "DATA_SOURCE_NAME"
-          valueFrom = {
-            secretKeyRef = {
-              name = kubernetes_secret.postgres_exporter.metadata[0].name
-              key  = "DATA_SOURCE_NAME"
-            }
-          }
+          value = "postgresql://${var.rds_db_exporter_user}:${var.rds_db_exporter_password}@${var.rds_endpoint}:5432/${var.rds_db_name}?sslmode=disable"
         }
       ]
 
       # 민감정보는 Secret에서 주입
-      envFromSecret = kubernetes_secret.postgres_exporter.metadata[0].name
+      envFromSecret = null# kubernetes_secret.postgres_exporter.metadata[0].name
 
       # ServiceMonitor를 만들어 kube-prometheus-stack이 자동 스크레이프
       serviceMonitor = {

--- a/modules/monitoring/prometheus/main.tf
+++ b/modules/monitoring/prometheus/main.tf
@@ -54,7 +54,7 @@ resource "helm_release" "postgres_exporter" {
 
   values = [
     yamlencode({
-      env = [
+      extraEnv = [
         {
           name = "DATA_SOURCE_URI"
           value = "${var.rds_endpoint}:5432/${var.rds_db_name}?sslmode=disable"

--- a/modules/monitoring/prometheus/main.tf
+++ b/modules/monitoring/prometheus/main.tf
@@ -54,8 +54,32 @@ resource "helm_release" "postgres_exporter" {
 
   values = [
     yamlencode({
+      env = [
+        {
+          name = "DATA_SOURCE_URI"
+          value = "${var.rds_endpoint}:5432/${var.rds_db_name}?sslmode=disable"
+        },
+        {
+          name = "DATA_SOURCE_USER"
+          valueFrom = {
+            secretKeyRef = {
+              name = kubernetes_secret.postgres_exporter.metadata[0].name
+              key  = "DATA_SOURCE_USER"
+            }
+          }
+        },
+        {
+          name = "DATA_SOURCE_PASS"
+          valueFrom = {
+            secretKeyRef = {
+              name = kubernetes_secret.postgres_exporter.metadata[0].name
+              key  = "DATA_SOURCE_PASS"
+            }
+          }
+        }
+      ]
       # 민감정보는 Secret에서 주입
-      envFromSecret = kubernetes_secret.postgres_exporter.metadata[0].name
+      # envFromSecret = kubernetes_secret.postgres_exporter.metadata[0].name
 
       # ServiceMonitor를 만들어 kube-prometheus-stack이 자동 스크레이프
       serviceMonitor = {

--- a/modules/monitoring/prometheus/main.tf
+++ b/modules/monitoring/prometheus/main.tf
@@ -54,30 +54,16 @@ resource "helm_release" "postgres_exporter" {
 
   values = [
     yamlencode({
-      extraEnv = [
-        {
-          name = "DATA_SOURCE_URI"
-          value = "${var.rds_endpoint}:5432/${var.rds_db_name}?sslmode=disable"
-        },
-        {
-          name = "DATA_SOURCE_USER"
-          valueFrom = {
-            secretKeyRef = {
-              name = kubernetes_secret.postgres_exporter.metadata[0].name
-              key  = "DATA_SOURCE_USER"
-            }
-          }
-        },
-        {
-          name = "DATA_SOURCE_PASS"
-          valueFrom = {
-            secretKeyRef = {
-              name = kubernetes_secret.postgres_exporter.metadata[0].name
-              key  = "DATA_SOURCE_PASS"
-            }
-          }
+      config = {
+        datasource = {
+          host     = var.rds_endpoint
+          port     = "5432"
+          user     = var.rds_db_exporter_user
+          dbname   = var.rds_db_name
+          sslmode  = "disable"
+          password = var.rds_db_exporter_password
         }
-      ]
+      }
       # 민감정보는 Secret에서 주입
       # envFromSecret = kubernetes_secret.postgres_exporter.metadata[0].name
 

--- a/modules/monitoring/prometheus/main.tf
+++ b/modules/monitoring/prometheus/main.tf
@@ -56,10 +56,17 @@ resource "helm_release" "postgres_exporter" {
 
   values = [
     yamlencode({
-      image = {
-        # 필요 시 고정 버전 사용 가능 (예: "v0.15.0")
-        # tag = "v0.15.0"
-      }
+      env = [
+        {
+          name  = "DATA_SOURCE_NAME"
+          valueFrom = {
+            secretKeyRef = {
+              name = kubernetes_secret.postgres_exporter.metadata[0].name
+              key  = "DATA_SOURCE_NAME"
+            }
+          }
+        }
+      ]
 
       # 민감정보는 Secret에서 주입
       envFromSecret = kubernetes_secret.postgres_exporter.metadata[0].name

--- a/modules/monitoring/prometheus/main.tf
+++ b/modules/monitoring/prometheus/main.tf
@@ -56,12 +56,9 @@ resource "helm_release" "postgres_exporter" {
 
   values = [
     yamlencode({
-      env = [
-        {
-          name  = "DATA_SOURCE_NAME"
-          value = "postgresql://${var.rds_db_exporter_user}:${var.rds_db_exporter_password}@${var.rds_endpoint}:5432/${var.rds_db_name}?sslmode=disable"
-        }
-      ]
+      config = {
+      datasource = "postgresql://${var.rds_db_exporter_user}:${var.rds_db_exporter_password}@${var.rds_endpoint}:5432/${var.rds_db_name}?sslmode=disable"
+    }
 
       # 민감정보는 Secret에서 주입
       envFromSecret = null# kubernetes_secret.postgres_exporter.metadata[0].name

--- a/modules/monitoring/prometheus/main.tf
+++ b/modules/monitoring/prometheus/main.tf
@@ -56,6 +56,10 @@ resource "helm_release" "postgres_exporter" {
 
   values = [
     yamlencode({
+      config = {
+        datasource = null  # 기본값 무력화
+      }
+
       extraEnv = [
         {
           name  = "DATA_SOURCE_NAME"

--- a/modules/monitoring/prometheus/main.tf
+++ b/modules/monitoring/prometheus/main.tf
@@ -55,13 +55,16 @@ resource "helm_release" "postgres_exporter" {
   chart      = "prometheus-postgres-exporter"
   version    = var.postgres_exporter_chart_version
   namespace  = var.namespace
+  force_update = true
 
   values = [
     yamlencode({
-      existingSecret = {
-        enabled = true
-        name    = kubernetes_secret.postgres_exporter_config.metadata[0].name
-      }
+      config = {
+        existingSecret = {
+          enabled = true
+          name    = kubernetes_secret.postgres_exporter_config.metadata[0].name
+        }
+      },
       # 민감정보는 Secret에서 주입
       # envFromSecret = kubernetes_secret.postgres_exporter.metadata[0].name
 

--- a/modules/web_hosting/main.tf
+++ b/modules/web_hosting/main.tf
@@ -16,14 +16,23 @@ resource "aws_s3_bucket_policy" "static_site_policy" {
   bucket = var.bucket_id
 
   policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect    = "Allow"
-      Principal = "*"
-      Action    = "s3:GetObject"
-      #Resource  = "arn:aws:s3:::${var.bucket_name}/*"
-      Resource = "${var.bucket_arn}/*"
-    }]
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid    = "AllowCloudFrontServiceAccessOnly",
+        Effect = "Allow",
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        },
+        Action   = "s3:GetObject",
+        Resource = "${var.bucket_arn}/*",
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = "arn:aws:cloudfront::194722398200:distribution/E1O23LTYRS9I1"
+          }
+        }
+      }
+    ]
   })
 
   depends_on = [aws_s3_bucket_public_access_block.allow_public]
@@ -40,8 +49,8 @@ resource "aws_s3_bucket_versioning" "static_site_versioning" {
 resource "aws_s3_bucket_public_access_block" "allow_public" {
   bucket = var.bucket_id
 
-  block_public_acls       = false
-  block_public_policy     = false
-  ignore_public_acls      = false
-  restrict_public_buckets = false
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -49,9 +49,9 @@ module "grafana" {
 }
 
 module "app_metrics_backend" {
-  count  = var.enable_k8s_addons ? 1 : 0
+  count  = var.enable_k8s_addons ? 1 : 1
   source = "./modules/monitoring/app_metrics"
-  enabled = var.enable_k8s_addons
+  enabled = true # var.enable_k8s_addons
 
   namespace           = "backend-dev"
   app_name            = "backend-api"


### PR DESCRIPTION
## ✨ 변경 내용
- External DNS 설정을 위한 서비스 계정 자동 토큰 마운트 처리
- Grafana Ingress 설정 및 Prometheus 연동 주소 수정
- JVM 서비스 모니터링용 Grafana 대시보드 템플릿 추가 및 개선
- Redis 인증 토큰 비활성화 및 TLS 비활성화
- DocumentDB 엔진 버전 변경 (5.0.0 → 4.0.0)
- ArgoCD Ingress HTTPS redirect 해제 및 8080 포트 노출
- Flyway Job 개선: placeholder 문법 수정 및 SQL 분리
- Prometheus Postgres Exporter 설정 개선
  - Secret을 통해 `postgres_exporter.yml` config 주입 방식으로 전환
  - `DATA_SOURCE_NAME` 환경변수 명시적 설정
- Terraform 리소스 및 보안그룹 세부 수정
  - DNS UDP 트래픽 허용
  - S3 버킷 정책 보완
---

## 💬 기타 사항
- Flyway Job의 `placeholder` 구문이 Flyway 8+ 버전에 맞춰 조정되었습니다.
- `prometheus-postgres-exporter`는 `existingSecret` 기반으로 설정되며, ConfigMap이 아닌 Secret 기반의 config 파일을 사용합니다.
